### PR TITLE
add lambda:CreateFunction to ATTACH_POLICY

### DIFF
--- a/zappa/zappa.py
+++ b/zappa/zappa.py
@@ -112,7 +112,8 @@ ATTACH_POLICY = """{
         {
             "Effect": "Allow",
             "Action": [
-                "lambda:InvokeFunction"
+                "lambda:InvokeFunction",
+                "lambda:CreateFunction"
             ],
             "Resource": [
                 "*"


### PR DESCRIPTION
## Description


## GitHub Issues
<!-- Proposed changes should be discussed in an issue before submitting a PR. -->
<!-- Link to relevant tickets here. -->


the zappa-permissions IAM inline policy did not include "lambda:CreateFunction" as a permission and would fail during a deploy without it being added.